### PR TITLE
Fix route conflict with other oauth extensions

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -44,7 +44,7 @@ return [
 
     (new Extend\Routes('forum'))
         ->get('/auth/twitter', 'auth.twitter', Controllers\TwitterAuthController::class)
-        ->get('/auth/{provider}', 'fof-oauth', Controllers\AuthController::class),
+        ->get(new OAuth2RoutePattern(), 'fof-oauth', Controllers\AuthController::class),
 
     (new Extend\Compat(function (Application $app, Dispatcher $events) {
         $app->register(OAuthServiceProvider::class);

--- a/src/OAuth2RoutePattern.php
+++ b/src/OAuth2RoutePattern.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of fof/oauth.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\OAuth;
 
 /**
  * We use an object that can be cast to string, because it allows us to use the Flarum Route extender
  * Without having to build the URL during the booting container event
- * By using __toString, the code will only be evaluated when Flarum resolves flarum.forum.routes
+ * By using __toString, the code will only be evaluated when Flarum resolves flarum.forum.routes.
  */
 class OAuth2RoutePattern
 {
@@ -26,6 +35,6 @@ class OAuth2RoutePattern
             $providerNames[] = $provider->name();
         }
 
-        return '/auth/{provider:' . implode('|', $providerNames) . '}';
+        return '/auth/{provider:'.implode('|', $providerNames).'}';
     }
 }

--- a/src/OAuth2RoutePattern.php
+++ b/src/OAuth2RoutePattern.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FoF\OAuth;
+
+/**
+ * We use an object that can be cast to string, because it allows us to use the Flarum Route extender
+ * Without having to build the URL during the booting container event
+ * By using __toString, the code will only be evaluated when Flarum resolves flarum.forum.routes
+ */
+class OAuth2RoutePattern
+{
+    public function __toString(): string
+    {
+        /**
+         * @var Provider[] $providers
+         */
+        $providers = app()->tagged('fof-oauth.providers');
+
+        $providerNames = [];
+
+        foreach ($providers as $provider) {
+            if (!$provider->enabled()) {
+                continue;
+            }
+
+            $providerNames[] = $provider->name();
+        }
+
+        return '/auth/{provider:' . implode('|', $providerNames) . '}';
+    }
+}

--- a/src/OAuth2RoutePattern.php
+++ b/src/OAuth2RoutePattern.php
@@ -28,7 +28,9 @@ class OAuth2RoutePattern
         $providerNames = [];
 
         foreach ($providers as $provider) {
-            if (!$provider->enabled()) {
+            // Skip disabled providers, this increases compatibility with other oauth extensions which might offer the same providers
+            // Skip Twitter because it has its own oauth1 route defined in extend.php
+            if (!$provider->enabled() || $provider->name() === 'twitter') {
                 continue;
             }
 


### PR DESCRIPTION
Solution test locally. Tested with WP Login extension trying the two orders they can be enabled.

Thinking behind this solution:

- It's best to keep a route binding because it means we don't need to change anything else in the code
- Dynamically generating the pattern is good because we can skip defining routes which we don't use. It allows using a third-party extension that offers one provider that you have disabled in FoF OAuth. Except Twitter route which is always defined
- Dynamic generation also means adding new providers doesn't require updating the route definition
- The use of a `__toString` class allows using the route extender and not having to define a `flarum.forum.routes` resolving binding ourselves outside of Flarum's public extenders

This is a new PR replacing #11 which I accidentally merged with missing commits and before anyone could review :hankey: 