### PR TITLE
Update of some brand colors

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -20,11 +20,11 @@
   }
 
   &.LogInButton--discord {
-    .Button--color(#fff, #7289da);
+    .Button--color(#fff, #5865F2);
   }
 
   &.LogInButton--facebook {
-    .Button--color(#fff, #3b5998);
+    .Button--color(#fff, #1877F2);
   }
 
   &.LogInButton--github {
@@ -32,7 +32,7 @@
   }
 
   &.LogInButton--twitter {
-    .Button--color(#fff, #55ADEE);
+    .Button--color(#fff, #1d9bf0);
   }
 
   &.LogInButton--gitlab {


### PR DESCRIPTION
This PR is simply to update the Facebook, Discord and Twitter colors according to current brand guidelines.

Reference links:
Facebook (https://developers.facebook.com/docs/facebook-login/userexperience/)
Discord (https://discord.com/branding)
Twitter (https://about.twitter.com/en/who-we-are/brand-toolkit)