### PR TITLE
Fix: missing call to releaseEvents for fireing the EmailChanged event

### DIFF
--- a/src/Jobs/CheckAndUpdateUserEmail.php
+++ b/src/Jobs/CheckAndUpdateUserEmail.php
@@ -76,8 +76,7 @@ class CheckAndUpdateUserEmail implements ShouldQueue
             $user->changeEmail($this->providedEmail);
 
             $user->save();
-
-			$user->releaseEvents();
+            $user->releaseEvents();
         }
     }
 }

--- a/src/Jobs/CheckAndUpdateUserEmail.php
+++ b/src/Jobs/CheckAndUpdateUserEmail.php
@@ -76,6 +76,8 @@ class CheckAndUpdateUserEmail implements ShouldQueue
             $user->changeEmail($this->providedEmail);
 
             $user->save();
+
+			$user->releaseEvents();
         }
     }
 }


### PR DESCRIPTION
**Fixes: missing fireing of the EmailChanged event **

**Changes proposed in this pull request:**
add releaseEvents() after saving the user model
