### PR TITLE
feat: Assign signups via oauth to specified groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ By default these providers are included:
 
 This extension provides the ability to view the status of linked OAuth providers (intended for admin and/or moderator use). In order for this to function correctly, you must also set the permission `Moderate Access Tokens` to at least the same group as you require for `Moderate user's linked accounts`.
 
+### Group Assignment
+
+You can configure each OAuth provider to automatically assign users to a specific group when they register. This is useful for tracking which provider users signed up with or for granting specific permissions based on the authentication method.
+
+To configure group assignment:
+1. Go to the extension settings
+2. Enable the desired OAuth provider
+3. Click the settings icon for that provider
+4. Select a group from the "Assign Group" dropdown
+5. Save your changes
+
+Users who register through that provider will automatically be assigned to the selected group.
+
 ### Additional providers
 
 Additional OAuth providers are available for this extension. Here's a handy list of known extensions, let us know if you know of any more and we'll get them added!

--- a/extend.php
+++ b/extend.php
@@ -16,6 +16,7 @@ use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Extend;
 use Flarum\Frontend\Document;
 use Flarum\User\Event\LoggedOut;
+use Flarum\User\Event\RegisteringFromProvider;
 use Flarum\User\Filter\UserFilterer;
 use Flarum\User\Search\UserSearcher;
 use FoF\Extend\Events\OAuthLoginSuccessful;
@@ -68,6 +69,7 @@ return [
         ->default('fof-oauth.log-oauth-errors', false),
 
     (new Extend\Event())
+        ->listen(RegisteringFromProvider::class, Listeners\AssignGroupToUser::class)
         ->listen(OAuthLoginSuccessful::class, Listeners\UpdateEmailFromProvider::class)
         ->listen(LoggedOut::class, Listeners\HandleLogout::class)
         ->subscribe(Listeners\ClearOAuthCache::class),

--- a/js/src/admin/components/AuthSettingsPage.js
+++ b/js/src/admin/components/AuthSettingsPage.js
@@ -167,32 +167,30 @@ export default class AuthSettingsPage extends ExtensionPage {
       <div className="Form-group">
         <label>{app.translator.trans('fof-oauth.admin.settings.providers.group_label')}</label>
         <div className="helpText">{app.translator.trans('fof-oauth.admin.settings.providers.group_help')}</div>
-        
+
         {(() => {
           const groupId = this.setting(`fof-oauth.${name}.group`)();
           const selectedGroup = groupId ? app.store.getById('groups', groupId) : null;
           const icons = {
-            1: 'fas fa-check',  // Admins
-            3: 'fas fa-user',   // Members
-            4: 'fas fa-map-pin' // Mods
+            1: 'fas fa-check', // Admins
+            3: 'fas fa-user', // Members
+            4: 'fas fa-map-pin', // Mods
           };
-          
+
           return (
-            <Dropdown 
-              label={selectedGroup 
-                ? [icon(selectedGroup.icon() || icons[selectedGroup.id()]), '\t', selectedGroup.namePlural()] 
-                : app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')}
+            <Dropdown
+              label={
+                selectedGroup
+                  ? [icon(selectedGroup.icon() || icons[selectedGroup.id()]), '\t', selectedGroup.namePlural()]
+                  : app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')
+              }
               buttonClassName="Button"
               disabled={!this.setting(`fof-oauth.${name}`)()}
             >
-              <Button
-                icon="fas fa-times"
-                onclick={() => this.setting(`fof-oauth.${name}.group`)('')}
-                active={!groupId}
-              >
+              <Button icon="fas fa-times" onclick={() => this.setting(`fof-oauth.${name}.group`)('')} active={!groupId}>
                 {app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')}
               </Button>
-              
+
               {this.getAvailableGroups().map((group) => (
                 <Button
                   icon={group.icon() || icons[group.id()]}

--- a/js/src/admin/components/AuthSettingsPage.js
+++ b/js/src/admin/components/AuthSettingsPage.js
@@ -1,5 +1,6 @@
 import app from 'flarum/admin/app';
 import Button from 'flarum/common/components/Button';
+import Dropdown from 'flarum/common/components/Dropdown';
 import ExtensionPage from 'flarum/admin/components/ExtensionPage';
 import icon from 'flarum/common/helpers/icon';
 import ItemList from 'flarum/common/utils/ItemList';
@@ -152,8 +153,61 @@ export default class AuthSettingsPage extends ExtensionPage {
     return items;
   }
 
+  getAvailableGroups() {
+    const groups = app.store.all('groups');
+    return groups.filter((group) => group.id() !== '2'); // Exclude the "Guests" group
+  }
+
   customProviderSettings(name) {
     const items = new ItemList();
+
+    // Add group selection dropdown
+    items.add(
+      'group',
+      <div className="Form-group">
+        <label>{app.translator.trans('fof-oauth.admin.settings.providers.group_label')}</label>
+        <div className="helpText">{app.translator.trans('fof-oauth.admin.settings.providers.group_help')}</div>
+        
+        {(() => {
+          const groupId = this.setting(`fof-oauth.${name}.group`)();
+          const selectedGroup = groupId ? app.store.getById('groups', groupId) : null;
+          const icons = {
+            1: 'fas fa-check',  // Admins
+            3: 'fas fa-user',   // Members
+            4: 'fas fa-map-pin' // Mods
+          };
+          
+          return (
+            <Dropdown 
+              label={selectedGroup 
+                ? [icon(selectedGroup.icon() || icons[selectedGroup.id()]), '\t', selectedGroup.namePlural()] 
+                : app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')}
+              buttonClassName="Button"
+              disabled={!this.setting(`fof-oauth.${name}`)()}
+            >
+              <Button
+                icon="fas fa-times"
+                onclick={() => this.setting(`fof-oauth.${name}.group`)('')}
+                active={!groupId}
+              >
+                {app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')}
+              </Button>
+              
+              {this.getAvailableGroups().map((group) => (
+                <Button
+                  icon={group.icon() || icons[group.id()]}
+                  onclick={() => this.setting(`fof-oauth.${name}.group`)(group.id())}
+                  active={groupId === group.id()}
+                  key={group.id()}
+                >
+                  {group.namePlural()}
+                </Button>
+              ))}
+            </Dropdown>
+          );
+        })()}
+      </div>
+    );
 
     return items;
   }

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -39,7 +39,7 @@
     max-height: 0;
     margin-bottom: 0;
     transition:
-        max-height 0.25s,
+        max-height 0.5s,
         margin-bottom 0.25s;
     overflow-y: hidden;
     overflow-x: visible;
@@ -56,9 +56,9 @@
     }
 
     &.showing .Provider--settings {
-      max-height: 600px;
+      max-height: 2000px;
       margin-bottom: 25px;
-      overflow-y: auto;
+      overflow-y: visible;
       padding: 0 5px 5px;
     }
   }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -24,6 +24,9 @@ fof-oauth:
 
       providers:
         callback_url_text: If necessary, set the callback URL to {url}.
+        group_label: Assign Group
+        group_help: Select a group to automatically assign to users who register using this provider.
+        no_group_label: No group assignment
 
         discord:
           description: Create an app at {link}. Add the redirect URL in the OAuth2 tab.

--- a/src/Listeners/AssignGroupToUser.php
+++ b/src/Listeners/AssignGroupToUser.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of fof/oauth.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\OAuth\Listeners;
+
+use Flarum\Group\Group;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Event\RegisteringFromProvider;
+use Flarum\User\User;
+
+class AssignGroupToUser
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @param SettingsRepositoryInterface $settings
+     */
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * @param RegisteringFromProvider $event
+     */
+    public function handle(RegisteringFromProvider $event)
+    {
+        $provider = $event->provider;
+        $user = $event->user;
+        
+        // Get the group ID for this provider
+        $groupId = $this->settings->get("fof-oauth.{$provider}.group");
+        
+        // If a group is specified, assign it to the user
+        if ($groupId && is_numeric($groupId)) {
+            $user->afterSave(function (User $user) use ($groupId) {
+                // Attach the group to the user
+                $user->groups()->attach($groupId);
+            });
+        }
+    }
+}

--- a/src/Listeners/AssignGroupToUser.php
+++ b/src/Listeners/AssignGroupToUser.php
@@ -38,10 +38,10 @@ class AssignGroupToUser
     {
         $provider = $event->provider;
         $user = $event->user;
-        
+
         // Get the group ID for this provider
         $groupId = $this->settings->get("fof-oauth.{$provider}.group");
-        
+
         // If a group is specified, assign it to the user
         if ($groupId && is_numeric($groupId)) {
             $user->afterSave(function (User $user) use ($groupId) {


### PR DESCRIPTION
Allow setting a default group to users signing up via OAuth providers.

Each provider can specify a different group as required.

![image](https://github.com/user-attachments/assets/1473d8a0-b6e8-4eae-b29a-63c9eb3de405)

