### PR TITLE
[2.x] fix: expose admin/forum components to ExportRegistry; convert admin to TS

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -178,6 +178,7 @@ If you maintain one of these extensions, the changes above apply to you:
 - [Auth0](https://extiverse.com/extension/lodge104/flarum-ext-oauth-auth0)
 - [Line](https://extiverse.com/extension/ianm/oauth-line)
 - [Microsoft](https://flarum.org/extension/xrh0905/oauth-microsoft)
+- [Reddit](https://github.com/imorland/flarum-ext-oauth-reddit)
 - [Slack](https://extiverse.com/extension/blomstra/oauth-slack)
 - [Twitch](https://github.com/imorland/flarum-ext-oauth-twitch)
 

--- a/js/src/@types/shims.d.ts
+++ b/js/src/@types/shims.d.ts
@@ -1,5 +1,13 @@
 import 'flarum/forum/ForumApplication';
+import 'flarum/admin/AdminApplication';
 import 'flarum/common/models/User';
+
+export interface OAuthAdminProvider {
+  name: string;
+  icon: string;
+  link: string;
+  fields: Record<string, string>;
+}
 
 declare module 'flarum/forum/ForumApplication' {
   export default interface ForumApplication {
@@ -7,6 +15,12 @@ declare module 'flarum/forum/ForumApplication' {
     fof_oauth_linkingProvider?: string;
     fof_oauth_loginInProgress?: boolean;
     linkingComplete: () => Promise<void>;
+  }
+}
+
+declare module 'flarum/admin/AdminApplication' {
+  interface AdminApplicationData {
+    'fof-oauth': OAuthAdminProvider[];
   }
 }
 

--- a/js/src/admin/components/AuthSettingsPage.tsx
+++ b/js/src/admin/components/AuthSettingsPage.tsx
@@ -5,12 +5,16 @@ import ExtensionPage from 'flarum/admin/components/ExtensionPage';
 import Icon from 'flarum/common/components/Icon';
 import Badge from 'flarum/common/components/Badge';
 import ItemList from 'flarum/common/utils/ItemList';
+import type Group from 'flarum/common/models/Group';
+import type Mithril from 'mithril';
 
 export default class AuthSettingsPage extends ExtensionPage {
-  oninit(vnode) {
+  showing: Record<string, boolean> = {};
+
+  oninit(vnode: Mithril.Vnode<this['attrs'], this>) {
     super.oninit(vnode);
 
-    this.showing = [];
+    this.showing = {};
   }
 
   content() {
@@ -59,17 +63,17 @@ export default class AuthSettingsPage extends ExtensionPage {
     );
   }
 
-  providerSettingsItems() {
-    const items = new ItemList();
+  providerSettingsItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
 
-    app.data['fof-oauth'].map((provider) => {
+    app.data['fof-oauth'].forEach((provider) => {
       const { name } = provider;
       const enabled = !!Number(this.setting(`fof-oauth.${name}`)());
       const showSettings = !!this.showing[name];
-      const callbackUrl = `${app.forum.attribute('baseUrl')}/auth/${name}`;
+      const callbackUrl = `${app.forum.attribute<string>('baseUrl')}/auth/${name}`;
 
       const groupId = this.setting(`fof-oauth.${name}.group`)();
-      const selectedGroup = groupId ? app.store.getById('groups', groupId) : null;
+      const selectedGroup = groupId ? app.store.getById<Group>('groups', groupId) : null;
 
       items.add(
         `fof-oauth.${name}`,
@@ -88,7 +92,6 @@ export default class AuthSettingsPage extends ExtensionPage {
 
             {enabled && selectedGroup && (
               <div className="Provider--group">
-                {/*<Icon name={selectedGroup.icon() || 'fas fa-user-group'} />*/}
                 <Badge icon={selectedGroup.icon() || 'fas fa-user-group'} />
                 {selectedGroup.namePlural()}
               </div>
@@ -125,14 +128,14 @@ export default class AuthSettingsPage extends ExtensionPage {
               })}
             </p>
 
-            <div class="Form">
+            <div className="Form">
               {Object.keys(provider.fields).map((field) =>
                 this.buildSettingComponent({
                   type: 'string',
                   setting: `fof-oauth.${name}.${field}`,
                   label: app.translator.trans(`fof-oauth.admin.settings.providers.${name}.${field}_label`),
                   required: {
-                    [showSettings && provider.fields[field].includes('required') ? 'required' : null]: true,
+                    [showSettings && provider.fields[field].includes('required') ? 'required' : (null as unknown as string)]: true,
                   },
                 })
               )}
@@ -147,13 +150,13 @@ export default class AuthSettingsPage extends ExtensionPage {
     return items;
   }
 
-  getAvailableGroups() {
-    const groups = app.store.all('groups');
-    return groups.filter((group) => !['2', '3'].includes(group.id())); // Exclude the "Guests" and "Members" groups
+  getAvailableGroups(): Group[] {
+    const groups = app.store.all<Group>('groups');
+    return groups.filter((group) => !['2', '3'].includes(group.id()!)); // Exclude the "Guests" and "Members" groups
   }
 
-  customProviderSettings(name) {
-    const items = new ItemList();
+  customProviderSettings(name: string): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
 
     // Add group selection dropdown
     items.add(
@@ -164,8 +167,8 @@ export default class AuthSettingsPage extends ExtensionPage {
 
         {(() => {
           const groupId = this.setting(`fof-oauth.${name}.group`)();
-          const selectedGroup = groupId ? app.store.getById('groups', groupId) : null;
-          const icons = {
+          const selectedGroup = groupId ? app.store.getById<Group>('groups', groupId) : null;
+          const icons: Record<string, string> = {
             1: 'fas fa-check', // Admins
             3: 'fas fa-user', // Members
             4: 'fas fa-map-pin', // Mods
@@ -175,7 +178,7 @@ export default class AuthSettingsPage extends ExtensionPage {
             <Dropdown
               label={
                 selectedGroup
-                  ? [<Icon name={selectedGroup.icon() || icons[selectedGroup.id()]} />, '\t', selectedGroup.namePlural()]
+                  ? [<Icon name={selectedGroup.icon() || icons[selectedGroup.id()!]} />, '\t', selectedGroup.namePlural()]
                   : app.translator.trans('fof-oauth.admin.settings.providers.no_group_label')
               }
               buttonClassName="Button"
@@ -187,8 +190,8 @@ export default class AuthSettingsPage extends ExtensionPage {
 
               {this.getAvailableGroups().map((group) => (
                 <Button
-                  icon={group.icon() || icons[group.id()]}
-                  onclick={() => this.setting(`fof-oauth.${name}.group`)(group.id())}
+                  icon={group.icon() || icons[group.id()!]}
+                  onclick={() => this.setting(`fof-oauth.${name}.group`)(group.id()!)}
                   active={groupId === group.id()}
                   key={group.id()}
                 >

--- a/js/src/admin/components/ConfigureWithOAuthButton.tsx
+++ b/js/src/admin/components/ConfigureWithOAuthButton.tsx
@@ -3,10 +3,10 @@ import LinkButton from 'flarum/common/components/LinkButton';
 
 export default class ConfigureWithOAuthButton extends LinkButton {
   view() {
-    return [
+    return (
       <LinkButton className="Button" href={app.route('extension', { id: 'fof-oauth' })}>
         {app.translator.trans('fof-oauth.admin.configure_button_label')}
-      </LinkButton>,
-    ];
+      </LinkButton>
+    );
   }
 }

--- a/js/src/admin/components/ConfigureWithOAuthPage.tsx
+++ b/js/src/admin/components/ConfigureWithOAuthPage.tsx
@@ -1,4 +1,5 @@
 import ExtensionPage from 'flarum/admin/components/ExtensionPage';
+import type Mithril from 'mithril';
 import ConfigureWithOAuthButton from './ConfigureWithOAuthButton';
 
 /**
@@ -6,18 +7,18 @@ import ConfigureWithOAuthButton from './ConfigureWithOAuthButton';
  * It is not used directly by `fof/oauth` itself.
  */
 export default class ConfigureWithOAuthPage extends ExtensionPage {
-  oninit(vnode) {
+  oninit(vnode: Mithril.Vnode<this['attrs'], this>) {
     super.oninit(vnode);
   }
 
   content() {
-    return [
+    return (
       <div className="container">
         <div className="OAuthSettingsPage">
           <br />
           <ConfigureWithOAuthButton />
         </div>
-      </div>,
-    ];
+      </div>
+    );
   }
 }

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -1,5 +1,6 @@
 import app from 'flarum/admin/app';
 export { default as extend } from './extend';
+export * from './components';
 
 app.initializers.add('fof/oauth', () => {
   //

--- a/js/src/forum/components/index.ts
+++ b/js/src/forum/components/index.ts
@@ -1,0 +1,11 @@
+import AccountLinkedModal from './AccountLinkedModal';
+import LinkedAccounts from './LinkedAccounts';
+import LinkStatus from './LinkStatus';
+import ProviderInfo from './ProviderInfo';
+
+export const components = {
+  AccountLinkedModal,
+  LinkedAccounts,
+  LinkStatus,
+  ProviderInfo,
+};

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -3,6 +3,7 @@ import addLinkedAccountsToUserSecurityPage from './extenders/addLinkedAccountsTo
 import extendLoginSignup from './extenders/extendLoginSignup';
 
 export { default as extend } from './extend';
+export * from './components';
 
 app.initializers.add('fof/oauth', () => {
   extendLoginSignup();


### PR DESCRIPTION
## Summary

- `ConfigureWithOAuthPage.content()` returned `JSX.Element[]`, which widened the base `ExtensionPage.content(): JSX.Element` return type in `dist-typings`. Any TS-based OAuth provider extension that passed the page to `app.registry.for(...).registerPage(...)` failed to compile with TS2345.
- Even with that fixed, `ext:fof/oauth/admin/components/ConfigureWithOAuthPage` still threw at runtime with `No module found for fof-oauth:admin/components/ConfigureWithOAuthPage` — `js/src/admin/components/index.ts` exports the `components` object, but `js/src/admin/index.ts` never re-exported it, so `ExportRegistry` didn't know about them. Forum had the same missing re-export.
- While in the area, converted the remaining admin `.js` files to TS so their `.d.ts` output accurately describes the public API for consumers, and added a matching forum components barrel.

## Changes

- `ConfigureWithOAuthPage.content()` now returns a single `JSX.Element` (no array wrapping).
- `ConfigureWithOAuthButton.view()` same fix (previously `TSX` but still returning an array).
- Admin and forum `index.ts` now do `export * from './components'`.
- New `js/src/forum/components/index.ts` barrel (admin already had one).
- `AuthSettingsPage.js` / `ConfigureWithOAuthPage.js` / `ConfigureWithOAuthButton.tsx` migrated to typed TS, with `AdminApplicationData` augmented in `shims.d.ts` so `app.data['fof-oauth']` is typed.
- Unrelated: added Reddit to the OAuth provider extensions list in `UPGRADE.md`.

Closes #112